### PR TITLE
Ignore shortlink nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When scanning a site, the scanner will crawl everypage. On the retrieve html, th
 
 If any of those attributes start with `http://` the element will be regarded as mixed content.
 
-The package does not scan linked `.css` or `.js` files, not does it take inline `<script>` or `<style>` into consideration.
+The package does not scan linked `.css` or `.js` files, nor does it take inline `<script>` or `<style>` and [shortlinks](http://microformats.org/wiki/rel-shortlink) into consideration.
 
 ## Usage
 

--- a/src/MixedContentExtractor.php
+++ b/src/MixedContentExtractor.php
@@ -15,6 +15,15 @@ class MixedContentExtractor
             ->mapSpread(function ($tagName, $attribute) use ($html, $currentUri) {
                 return (new DomCrawler($html, $currentUri))
                     ->filterXPath("//{$tagName}[@{$attribute}]")
+                    ->reduce(function (DomCrawler $node) {
+                        $relAttr = $node->getNode(0)->attributes->getNamedItem('rel');
+
+                        if ($relAttr !== null && strtolower($relAttr->nodeValue) === 'shortlink') {
+                            return false;
+                        }
+
+                        return true;
+                    })
                     ->each(function (DomCrawler $node) use ($tagName, $attribute) {
                         $url = Url::create($node->attr($attribute));
 

--- a/tests/server/resources/views/noMixedContent.php
+++ b/tests/server/resources/views/noMixedContent.php
@@ -1,3 +1,3 @@
-<link rel="shortlink" href="http://example.com">
+<link rel="shortlink" href="http://example.com" />
 <img src="/relative-image.jpg" />
 <img src="https://absolute-image.jpg" />

--- a/tests/server/resources/views/noMixedContent.php
+++ b/tests/server/resources/views/noMixedContent.php
@@ -1,2 +1,3 @@
+<link rel="shortlink" href="http://example.com">
 <img src="/relative-image.jpg" />
 <img src="https://absolute-image.jpg" />


### PR DESCRIPTION
Currently ignores all nodes (not just `<link />`) with rel="shortlink" on them.

Fixes #9 