### PR TITLE
Improve PHPUnit fixture

### DIFF
--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -9,7 +9,7 @@ use Spatie\MixedContentScanner\MixedContentScanner;
 
 class MixedContentScannerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         Server::boot();
     }


### PR DESCRIPTION
According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.