### PR TITLE
Add tests to GitHub actions workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,3 +33,6 @@ jobs:
 
             -   name: Install dependencies
                 run: composer update --no-interaction --prefer-source
+
+            -   name: Execute tests
+                run: vendor/bin/phpunit

--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -61,7 +61,7 @@ class MixedContentScannerTest extends TestCase
             $logger = new MixedContentLogger();
 
             $scanner = (new MixedContentScanner($logger))->configureCrawler(function (Crawler $crawler) use ($crawlCount) {
-                $crawler->setMaximumCrawlCount($crawlCount);
+                $crawler->setTotalCrawlLimit($crawlCount);
             });
 
             $scanner->scan('http://'.Server::getServerUrl());

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -25,7 +25,7 @@ class Server
             return;
         }
 
-        $startServerCommand = 'php -S '.static::getServerUrl().' -t ./tests/server/public > /dev/null 2>&1 & echo $!';
+        $startServerCommand = 'php -S '.static::getRootServerUrl().' -t ./tests/server/public > /dev/null 2>&1 & echo $!';
 
         $pid = exec($startServerCommand);
 


### PR DESCRIPTION
After updating the package to support php 8 I noticed that the GitHub actions don't actually perform the tests (which failed). This PR fixes this.

To actually fix the tests I had to make the following changes:

1. Update the method to set the total crawl limit (which changed with the new version of the crawler)

2. Update the server start command. The old command failed with this error message.
```
Invalid address: localhost:9000/
```
Looks like php 8 does not support starting dev servers with a trailing slash in the server address